### PR TITLE
gh-6: make the help output more informative

### DIFF
--- a/cmd/fields/command.go
+++ b/cmd/fields/command.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	delimitersLabel = "cutset"
-	newLineLabel    = "newline"
+	// delimitersLabel = "cutset"
+	newLineLabel = "newline"
 )
 
 const (
@@ -23,7 +23,7 @@ const (
 
 func createFlagSet() *flag.FlagSet {
 	fs := flag.NewFlagSet("fields-flag-set", flag.ContinueOnError)
-	fs.String(delimitersLabel, "", "set of characters to cut on")
+	// fs.String(delimitersLabel, "", "set of characters to cut on")
 	fs.Bool(newLineLabel, true, "print trailing newline character")
 	return fs
 }
@@ -47,6 +47,11 @@ type command struct {
 }
 
 func (c *command) Execute(args []string) int {
+	if len(args) != 1 {
+		_, _ = fmt.Fprintf(c.io.stdErr, helpText)
+		return exitErr
+	}
+
 	delimiters, columns, err := setup(c.flags, args)
 	if err != nil {
 		_, _ = fmt.Fprintf(c.io.stdErr, "fatal: %v\n", err)
@@ -67,19 +72,21 @@ func (c *command) Execute(args []string) int {
 }
 
 func setup(fs *flag.FlagSet, args []string) (string, string, error) {
+	if len(args) != 1 {
+		return "", "", errors.Errorf("expected 1 argument, got %d", len(args))
+	}
+
 	err := fs.Parse(args)
 	if err != nil {
 		return "", "", errors.Wrapf(err, "parse args: %v", args)
 	}
 
-	separators := fs.Lookup(delimitersLabel).Value.String()
-	if separators != "" {
-		return "", "", errors.Errorf("custom cutsets not yet supported")
-	}
-
-	if fs.NArg() != 1 {
-		return "", "", errors.Errorf("expected 1 argument, got %d", fs.NArg())
-	}
+	// todo: support custom cutset
+	//separators := fs.Lookup(delimitersLabel).Value.String()
+	//if separators != "" {
+	//	return "", "", errors.Errorf("custom cutsets not yet supported")
+	//}
+	separators := ""
 
 	remArgs := fs.Args()
 	return separators, remArgs[0], nil

--- a/cmd/fields/command_test.go
+++ b/cmd/fields/command_test.go
@@ -31,6 +31,8 @@ func Test_setup_undefined_arg(t *testing.T) {
 }
 
 func Test_setup_cutset_nys(t *testing.T) {
+	t.Skip("custom cutset not yet supported")
+
 	fs := createFlagSet()
 	args := []string{"--cutset", "a"}
 	_, _, err := setup(fs, args)

--- a/cmd/fields/help.go
+++ b/cmd/fields/help.go
@@ -1,0 +1,52 @@
+package main
+
+const helpText = `fields - CLI columnar text processor [v1]
+	fields is a tool for selecting columns of text. One or more individual columns
+	and/or ranges of columns can be selected by index. Indexes can be positive
+	(counting from the left) or negative (counting from the right). Ranges can
+	bounded or unbounded (e.g. select all input to the left or right of N).
+
+	Input is expected on STDIN. Typically input is provided to fields through
+	pipes or redirection.
+
+	Usage)
+	fields [options] <columns>
+
+	Options)
+	- newline: print a trailing newline character (default true)
+
+	Syntax)
+	- Column indexes are counted starting from 1
+	- A positive index means start counting from the left
+	- A negative index means start counting from the right
+	- Closed ranges are denoted by two indexes separated by ':'
+	- Right open ranges are denoted by an index and a ':'
+	- Left open ranges are denoted by a ':' and an index
+	- High:Low ranges can reverse the order of columns
+	- Combine selections using comma separated list
+
+	Examples)
+	select a single column (from left)
+	  $ fields 3 <<< "a b c d e f g"			=> 3
+
+	select a single column (from right)
+	  $ fields -- -3 <<< "a b c d e f g"			=> e
+
+	select columns to the right of N (from left)
+	  $ fields 4: <<< "a b c d e f g"			=> d e f h
+
+	select columns to the right of N (from right)
+	  $ fields -- -2: <<< "a b c d e f g"			=> f g
+
+	select range of columns
+	  $ fields 2:5 <<< "a b c d e f g"			=> b c d e
+
+	select range of columns (reverse)
+	  $ fields 5:2 <<< "a b c d e f g"			=> e d c b
+
+	select multiple combinations
+	  $ fields -- -2,3:5,6: <<< "a b c d e f g"		=> f c d e f g
+
+	Bugs)
+	Report bugs & features requests @ https://github.com/shoenig/fields/issues
+`


### PR DESCRIPTION
Output lots of text describing how to use `fields` when no arguments are provided

Fixes #6 