### PR TITLE
gh-4: ignore empty lines when scanning input

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -20,17 +20,22 @@ func Apply(columns Columns, input io.Reader, output io.Writer) error {
 	scanner := bufio.NewScanner(input)
 
 	for scanner.Scan() {
-		line := scanner.Text()
-		if err := process(
-			line,
-			output,
-			columns,
-		); err != nil {
-			return err
+		if line := next(scanner); line != "" {
+			if err := process(
+				line,
+				output,
+				columns,
+			); err != nil {
+				return err
+			}
 		}
 	}
 
 	return scanner.Err()
+}
+
+func next(scanner *bufio.Scanner) string {
+	return strings.TrimSpace(scanner.Text())
 }
 
 func process(line string, output io.Writer, columns Columns) error {

--- a/apply_test.go
+++ b/apply_test.go
@@ -60,3 +60,15 @@ func Test_Apply_rightExp(t *testing.T) {
 	try(t, rec, "a b c d e f g", "c d e f g", false)
 	try(t, rec, "a b", "", true) // out of bounds
 }
+
+const textBlock = `
+a b c d
+e f g
+
+h i j
+`
+
+func Test_Apply_emptyLines(t *testing.T) {
+	ic2 := &individualColumn{column: 2}
+	try(t, ic2, textBlock, "b\nf\ni", false)
+}


### PR DESCRIPTION
This will avoid crashes, especially in the common
case where an input file my include empty trailing
or leading lines.