### PR TITLE
gh-9: be able to publish as a snap package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 **/cover.out
+**/*.snap
+
 cmd/fields/fields

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ columns of input text.
 
 # Getting Started
 
+#### Install from SnapCraft
+
+The `fields` command can be installed as a snap
+```bash
+$ sudo snap install fields
+```
+
+#### Build from source
+
 The `fields` command can be installed by running
 ```bash
 $ go get gophers.dev/cmds/fields/cmd/fields

--- a/snapcraft/snap/snapcraft.yaml
+++ b/snapcraft/snap/snapcraft.yaml
@@ -1,0 +1,26 @@
+name: fields
+base: core18
+version: 'v0.1.0'
+summary: CLI tool for parsing columnar text
+description: |
+  fields is a tool for selecting columns of text. One or more individual columns
+  and/or ranges of columns can be selected by index. Indexes can be positive
+  (counting from the left) or negative (counting from the right). Ranges can
+  bounded or unbounded (e.g. select all input to the left or right of N).
+
+grade: stable
+confinement: strict
+architectures:
+  - amd64
+
+apps:
+  fields:
+    command: bin/fields
+
+parts:
+  fields:
+    plugin: go
+    go-channel: 1.13/stable
+    source-tag: v0.1.0
+    go-packages: [github.com/shoenig/fields/cmd/fields]
+


### PR DESCRIPTION
Creates a snapcraft.yaml file which can be used to build and
publish as the "fields" command on the Canonical snapcraft catalog.

To install the snap, simply run
	$ sudo snap install fields

To build the snap, run `snapcraft` in the build
directory, and follow the publishing guide in
https://ubuntu.com/tutorials/create-your-first-snap#7-push-to-the-store